### PR TITLE
fix scoping issue in xkcd's search function

### DIFF
--- a/plugins/xkcd.rb
+++ b/plugins/xkcd.rb
@@ -2,7 +2,7 @@ require 'json'
 
 QUERY_URL = "http://api.duckduckgo.com/?q=!ducky+site:www.xkcd.com+%s&format=json&no_redirect=1"
 
-def search(q)
+def xkcd_search(q)
   output = http_get(QUERY_URL % CGI.escape(q)).body
   JSON.parse(output)["Redirect"].first
 end
@@ -12,6 +12,6 @@ command(:xkcd,
   :description => "Find an XKCD strip for a subject",
   :html => true
 ) do |message,q|
-  search_output = search(q)
+  search_output = xkcd_search(q)
   '<a href="%s">%s</a>' % [search_output, search_output]
 end


### PR DESCRIPTION
search() was calling the search defined in !hot
